### PR TITLE
Enable option to set minInterval

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -6,6 +6,10 @@
   "metrics": true,
   "mixed" : true,
 
+  "queryOptions": {
+	    "minInterval": true
+	  },
+	
   "info": {
     "version": "0.0.1",
     "author": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -6,6 +6,10 @@
   "metrics": true,
   "mixed" : true,
 
+  "queryOptions": {
+    "minInterval": true
+  },
+
   "info": {
     "version": "0.0.1",
     "author": {


### PR DESCRIPTION
This should add the Query option "Min time interval" to the plugin as discussed in https://github.com/GoshPosh/grafana-meta-queries/issues/47

The reference for why this should work is the "Mixed" plugin in the Grafana repository: https://github.com/grafana/grafana/blob/1165d098b0d0ae705955f9d2ea104beea98ca6eb/public/app/plugins/datasource/mixed/plugin.json#L10-L12

Here is a screenshot in Grafana after adding this modification

<img width="700" alt="2019-02-11 17-35-32" src="https://user-images.githubusercontent.com/42185/52577994-9d577b80-2e23-11e9-842a-5f9e58f0a10a.png">
