### PR TITLE
Increase arithmetic input field width

### DIFF
--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -57,7 +57,7 @@
       <label class="gf-form-label query-keyword width-10">
         Expression
       </label>
-      <input type="text" class="gf-form-input width-20" ng-model="ctrl.target.expression" spellcheck='false' placeholder="query" ng-blur="ctrl.targetBlur()"  />
+      <input type="text" class="gf-form-input width-30" ng-model="ctrl.target.expression" spellcheck='false' placeholder="query" ng-blur="ctrl.targetBlur()"  />
       <label class="gf-form-label" bs-tooltip="ctrl.target.errors.expression" style="color: rgb(229, 189, 28)" ng-show="ctrl.target.errors.expression">
         <i class="fa fa-warning"></i>
       </label>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -57,7 +57,7 @@
       <label class="gf-form-label query-keyword width-10">
         Expression
       </label>
-      <input type="text" class="gf-form-input width-20" ng-model="ctrl.target.expression" spellcheck='false' placeholder="query" ng-blur="ctrl.targetBlur()"  />
+      <input type="text" class="gf-form-input width-30" ng-model="ctrl.target.expression" spellcheck='false' placeholder="query" ng-blur="ctrl.targetBlur()"  />
       <label class="gf-form-label" bs-tooltip="ctrl.target.errors.expression" style="color: rgb(229, 189, 28)" ng-show="ctrl.target.errors.expression">
         <i class="fa fa-warning"></i>
       </label>


### PR DESCRIPTION
Increasing the width of the arithmetic input field from 'width-20' to 'width-30'. Even better would probably be changing it to a text area, but would involve more changes. So this is is a "good" start.

This is a small improvements for https://github.com/GoshPosh/grafana-meta-queries/issues/46