### PR TITLE
Correctly set plugin name and id

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -36,11 +36,16 @@ Lets you perform arithmetic operations on one or more existing queries.
 Grafana Meta Queries plugin 0.0.1 and above are supported for Grafana: 4.x.x
 
 
-## Known Issues
-* Moving average of moving average is not supported
-* Moving average of time shift is not supported
-* Time shift of Moving average is not supported
-* Time shift of Time Shift is not supported
+## Supports Nesting 
+* Moving average of moving average
+* Moving average of time shift
+* Time shift of Moving average 
+* Time shift of Time Shift
+
+## Known issue
+* Moving average on arithmetic is not supported
+* TimeShift on arithmetic is not supported
+
 
 ## Status
 Lot of features might still not be implemented. Your contributions are welcome.

--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -23,7 +23,9 @@ function (angular, _, dateMath, moment) {
   'use strict';
 
   /** @ngInject */
-  function MetaQueriesDatasource($q, datasourceSrv) {
+  function MetaQueriesDatasource(instanceSettings, $q, datasourceSrv) {
+    this.id = instanceSettings.id;
+    this.name = instanceSettings.name;
     this.datasourceSrv = datasourceSrv;
     this.$q = $q;
 

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -23,7 +23,9 @@ function (angular, _, dateMath, moment) {
   'use strict';
 
   /** @ngInject */
-  function MetaQueriesDatasource($q, datasourceSrv) {
+  function MetaQueriesDatasource(instanceSettings, $q, datasourceSrv) {
+    this.id = instanceSettings.id;
+    this.name = instanceSettings.name;
     this.datasourceSrv = datasourceSrv;
     this.$q = $q;
 


### PR DESCRIPTION
## Problem

Currently the name of the datasource is not shown in the interface of grafana.
![Screenshot 2019-09-18 at 13 51 29](https://user-images.githubusercontent.com/231804/65146249-a17ff300-da1b-11e9-94b9-13b81d9c1574.png)

## Solution

Correctly set the name and the id on the plugin in the constructor. This is the same as if using the new ES2015+/TS plugin api and extending DataSourceAPI (https://github.com/grafana/grafana/blob/v6.3.5/packages/grafana-ui/src/types/datasource.ts#L143)

After the change it looks like this:
![Screenshot 2019-09-18 at 13 52 01](https://user-images.githubusercontent.com/231804/65146386-f1f75080-da1b-11e9-8a27-104bbba0c62e.png)

I also called build and it generated `dist`, I hope it is okay to do that, otherwise I remove them again.

I'm not 100% certain, but I think this changed in 6.3 of grafana.