### PR TITLE
Easy Debugging with docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+grafana:
+  image: grafana/grafana:latest
+  ports:
+    - "3000:3000"
+  volumes:
+    - ./dist:/var/lib/grafana/plugins/grafana/grafana-meta-queries
+    - ./provisioning/datasources:/etc/grafana/provisioning/datasources
+  environment:
+    - TERM=linux

--- a/provisioning/datasource/dev.yaml
+++ b/provisioning/datasource/dev.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+  - orgId: 1
+    name: testdata
+
+# # list of datasources to insert/update depending
+# # on what's available in the datbase
+datasources:
+  - orgId: 1
+    name: TestData DB
+    type: testdata
+    isDefault: true
+    version: 1
+    editable: true


### PR DESCRIPTION
This adds two files for debugging, on is the docker-compose config and the other is the config for a fake test datasource.

How to use it:
1. Install docker for your OS
2. In the project folder run `docker-compose up`
3. go to http://127.0.0.1:3000/ and login with `admin:admin` and test the meta query plugin.
4. When you are done just press Ctrl+C in the commandline where docker-compose was running.

The version in the docker-compose config is set to `latest`, but can be changed to any version down to 2.x

Not sure if you want to merge this, it just made it super easy for me to test different versions.