### PR TITLE
Fix groupby for arithmetic bug

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -294,30 +294,71 @@ function (angular, _, dateMath, moment) {
           var functionArgs = queryLetters.join(', ');
           var functionBody = 'return ('+expression+');';
 
-          var metricNames = [];
-          var resultsHash= {};
-          for(var i=0;i<results.length;i++){
-            var resultByQuery = results[i];
-            for(var j=0;j<resultByQuery.data.length;j++){
-              var resultByQueryMetric = resultByQuery.data[j];
-              var metricName = resultByQueryMetric.target;
-              if(resultByQueryMetric.datapoints){
-                for(var k=0;k<resultByQueryMetric.datapoints.length;k++){
-                  var datapoint = resultByQueryMetric.datapoints[k];
-                  resultsHash[datapoint[1]] = resultsHash[datapoint[1]] || [];
-                  resultsHash[datapoint[1]][i] = resultsHash[datapoint[1]][i] || {};
-                  resultsHash[datapoint[1]][i][metricName] = datapoint[0]
+          if (functionBody.indexOf("{{") >= 0) {
+            var metricNames = new Set();
+            var resultsHash= {};
+            for(var i=0;i<results.length;i++){
+              var resultByQuery = results[i];
+              for(var j=0;j<resultByQuery.data.length;j++){
+                var resultByQueryMetric = resultByQuery.data[j];
+                var metricName = resultByQueryMetric.target;
+                if(resultByQueryMetric.datapoints){
+                  for(var k=0;k<resultByQueryMetric.datapoints.length;k++){
+                    var datapoint = resultByQueryMetric.datapoints[k];
+                    resultsHash[datapoint[1]] = resultsHash[datapoint[1]] || [];
+                    resultsHash[datapoint[1]][i] = resultsHash[datapoint[1]][i] || {};
+                    resultsHash[datapoint[1]][i][metricName] = datapoint[0]
+                  }
+                }
+                if (Object.keys(resultByQueryMetric.props).length > 0) {
+                  metricNames.add(metricName);
                 }
               }
-              metricNames.push(metricName);
             }
-          }
 
-          var pattern = /\{\{.*?\}\}/g;
-          var datas = [];
-          for (var metricName of metricNames) {
+            var pattern = /\{\{.*?\}\}/g;
+            var datas = [];
+            for (var metricName of metricNames) {
+              var datapoints= [];
+              var expressionFunction = new Function(functionArgs, functionBody.replace(pattern, metricName));
+              Object.keys(resultsHash).forEach(function (datapointTime) {
+                var data = resultsHash[datapointTime];
+                var result = 0;
+                try {
+                  result = expressionFunction.apply(this,data)
+                }
+                catch(err) {
+                  console.log(err);
+                }
+                datapoints.push([result,parseInt(datapointTime)])
+              });
+              datas.push({"target": outputMetricName.replace(pattern, metricName),
+                "datapoints": datapoints,
+                "hide": target.hide});
+            }
+            return {
+              data: datas
+            };
+          } else {
+            var expressionFunction = new Function(functionArgs, functionBody);
+
+            var resultsHash= {};
+            for(var i=0;i<results.length;i++){
+              var resultByQuery = results[i];
+              for(var j=0;j<resultByQuery.data.length;j++){
+                var resultByQueryMetric = resultByQuery.data[j];
+                var metricName = resultByQueryMetric.target;
+                if(resultByQueryMetric.datapoints){
+                  for(var k=0;k<resultByQueryMetric.datapoints.length;k++){
+                    var datapoint = resultByQueryMetric.datapoints[k];
+                    resultsHash[datapoint[1]] = resultsHash[datapoint[1]] || [];
+                    resultsHash[datapoint[1]][i] = resultsHash[datapoint[1]][i] || {};
+                    resultsHash[datapoint[1]][i][metricName] = datapoint[0]
+                  }
+                }
+              }
+            }
             var datapoints= [];
-            var expressionFunction = new Function(functionArgs, functionBody.replace(pattern, metricName));
             Object.keys(resultsHash).forEach(function (datapointTime) {
               var data = resultsHash[datapointTime];
               var result = 0;
@@ -329,13 +370,15 @@ function (angular, _, dateMath, moment) {
               }
               datapoints.push([result,parseInt(datapointTime)])
             });
-            datas.push({"target": outputMetricName.replace(pattern, metricName),
-              "datapoints": datapoints,
-              "hide": target.hide});
+
+            return {
+              data: [{
+                "target": outputMetricName,
+                "datapoints": datapoints,
+                "hide" : target.hide
+               }]
+             };
           }
-          return {
-            data: datas
-          };
     }
 
     function filter_datapoints(target, outputMetricName, results, root_query_results){

--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -291,50 +291,51 @@ function (angular, _, dateMath, moment) {
           var expression = target.expression;
           var queryLetters = Object.keys(targetsByRefId);
 
-
           var functionArgs = queryLetters.join(', ');
           var functionBody = 'return ('+expression+');';
 
-          var expressionFunction = new Function(functionArgs, functionBody);
-
+          var metricNames = [];
           var resultsHash= {};
           for(var i=0;i<results.length;i++){
-             var resultByQuery = results[i];
-             for(var j=0;j<resultByQuery.data.length;j++){
-               var resultByQueryMetric = resultByQuery.data[j];
-               var metricName = resultByQueryMetric.target;
-               if(resultByQueryMetric.datapoints){
-                 for(var k=0;k<resultByQueryMetric.datapoints.length;k++){
-                   var datapoint = resultByQueryMetric.datapoints[k];
-                   resultsHash[datapoint[1]] = resultsHash[datapoint[1]] || [];
-                   resultsHash[datapoint[1]][i] = resultsHash[datapoint[1]][i] || {};
-                   resultsHash[datapoint[1]][i][metricName] = datapoint[0]
-                 }
-               }
-             }
+            var resultByQuery = results[i];
+            for(var j=0;j<resultByQuery.data.length;j++){
+              var resultByQueryMetric = resultByQuery.data[j];
+              var metricName = resultByQueryMetric.target;
+              if(resultByQueryMetric.datapoints){
+                for(var k=0;k<resultByQueryMetric.datapoints.length;k++){
+                  var datapoint = resultByQueryMetric.datapoints[k];
+                  resultsHash[datapoint[1]] = resultsHash[datapoint[1]] || [];
+                  resultsHash[datapoint[1]][i] = resultsHash[datapoint[1]][i] || {};
+                  resultsHash[datapoint[1]][i][metricName] = datapoint[0]
+                }
+              }
+              metricNames.push(metricName);
+            }
+          }
 
-           }
-           var datapoints= [];
-           Object.keys(resultsHash).forEach(function (datapointTime) {
-             var data = resultsHash[datapointTime];
-             var result = 0;
-             try {
-               result = expressionFunction.apply(this,data)
-             }
-             catch(err) {
-               console.log(err);
-             }
-             datapoints.push([result,parseInt(datapointTime)])
-
-           });
-
-           return {
-             data: [{
-               "target": outputMetricName,
-               "datapoints": datapoints,
-               "hide" : target.hide
-              }]
-            };
+          var pattern = /\{\{.*?\}\}/g;
+          var datas = [];
+          for (var metricName of metricNames) {
+            var datapoints= [];
+            var expressionFunction = new Function(functionArgs, functionBody.replace(pattern, metricName));
+            Object.keys(resultsHash).forEach(function (datapointTime) {
+              var data = resultsHash[datapointTime];
+              var result = 0;
+              try {
+                result = expressionFunction.apply(this,data)
+              }
+              catch(err) {
+                console.log(err);
+              }
+              datapoints.push([result,parseInt(datapointTime)])
+            });
+            datas.push({"target": outputMetricName.replace(pattern, metricName),
+              "datapoints": datapoints,
+              "hide": target.hide});
+          }
+          return {
+            data: datas
+          };
     }
 
     function filter_datapoints(target, outputMetricName, results, root_query_results){


### PR DESCRIPTION
**Issue**: Fix PR #78 bug. It will produce multiple same datapoints when arithmetic over datapoints with groupby along with datapoints without groupby. I fix this bug in this PR.
**Datasource**: Elasticsearch(No testing for other datasource)
**Attention**: Only support for alias pattern {{term fieldname}}.
![Selection_013](https://user-images.githubusercontent.com/18626159/66999353-6fd87580-f108-11e9-8027-c7f20ddca3a1.png)
