### PR TITLE
Fixes the plugin for grafana 7.1.x

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -64,7 +64,7 @@ function (angular, _, dateMath, moment) {
           }
           else{
               opt.targets = targets;
-              return ds.query(opt);
+              return ds.query(opt).toPromise();
           }
 
         });
@@ -78,7 +78,7 @@ function (angular, _, dateMath, moment) {
                       var nonHiddenTarget = angular.copy(target);
                       nonHiddenTarget.hide = false;
                       opt.targets = [nonHiddenTarget];
-                      return ds.query(opt);
+                      return ds.query(opt).toPromise();
                   }
               });
           }

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -64,7 +64,7 @@ function (angular, _, dateMath, moment) {
           }
           else{
               opt.targets = targets;
-              return ds.query(opt);
+              return ds.query(opt).toPromise();
           }
 
         });
@@ -78,7 +78,7 @@ function (angular, _, dateMath, moment) {
                       var nonHiddenTarget = angular.copy(target);
                       nonHiddenTarget.hide = false;
                       opt.targets = [nonHiddenTarget];
-                      return ds.query(opt);
+                      return ds.query(opt).toPromise();
                   }
               });
           }


### PR DESCRIPTION
This fixes the plugin for Grafana 7.1.x. The return from ds.query() is an Observable, which can be converted to a promise with `toPromise()`