### PR TITLE
ds.query may return an Observable, not a Promise

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -199,7 +199,13 @@ function (angular, _, dateMath, moment) {
                 return timeshift(options.targets[0], options, targetsByRefId, datasourceSrv, metaTarget.outputMetricName)
             }
             else{
-                return ds.query(options)
+              var ds_res = ds.query(options);
+              if(ds_res.then){
+                return ds_res;
+                }
+              else{
+                return ds_res.toPromise();
+               }
             }
         });
         promise  = metaTargetPromise.then(function (result) {
@@ -268,7 +274,13 @@ function (angular, _, dateMath, moment) {
             }
 
             else{
-                return ds.query(options)
+              var ds_res = ds.query(options);
+              if(ds_res.then){
+                return ds_res;
+                }
+              else{
+                return ds_res.toPromise();
+               }
             }
         });
 


### PR DESCRIPTION
Saw issues with Grafana 7.5.4 and plugin 0.0.5 which I traced to ds.query returning an observable rather than a Promise