### PR TITLE
[grafana 8.0.x] Populate target.datasource with ds name if undefined 

### DIFF
--- a/dist/query_ctrl.ts
+++ b/dist/query_ctrl.ts
@@ -57,6 +57,9 @@ export class MetaQueriesQueryCtrl extends QueryCtrl {
       if (!this.target.timeshiftUnit) {
         this.target.timeshiftUnit = this.defaultTimeshiftUnit;
       }
+      if (!this.target.datasource) {
+        this.target.datasource = this.datasource.meta.name;
+      }
 
     this.getQueryLetters = (query, callback) => {
       return this.datasource.getTargets()

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -57,6 +57,9 @@ export class MetaQueriesQueryCtrl extends QueryCtrl {
       if (!this.target.timeshiftUnit) {
         this.target.timeshiftUnit = this.defaultTimeshiftUnit;
       }
+      if (!this.target.datasource) {
+        this.target.datasource = this.datasource.meta.name;
+      }
 
     this.getQueryLetters = (query, callback) => {
       return this.datasource.getTargets()


### PR DESCRIPTION
### Notes
`datasource` isn't available in props on first query creation in Grafana 8.0.x. This PR manually populates `target.datasource` in MetaQueries' query control if `datasource` is undefined. 


#### Grafana 7 Query Operation Row props -- `datasource` is defined for new queries
<img width="1340" alt="Screen Shot 2021-07-14 at 11 16 34 AM" src="https://user-images.githubusercontent.com/6889258/125654806-69d43dd5-9495-4d58-a178-2626c335d3d9.png">

#### Grafana 8 Query Operation Row props -- undefined `datasource` for new queries
<img width="1347" alt="Screen Shot 2021-07-14 at 11 19 59 AM" src="https://user-images.githubusercontent.com/6889258/125655187-8dd911bd-ee46-4b0a-b65e-cd202f7c55b5.png">

#### Grafana 8 Query Operation Row props -- `datasource` is defined after some steps
<img width="1346" alt="Screen Shot 2021-07-14 at 11 24 44 AM" src="https://user-images.githubusercontent.com/6889258/125655642-b61ffc9d-880b-429a-bd7b-05532d2fbead.png">



